### PR TITLE
MakeSD directory was removed but still referenced by readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ C++ Source is found in the *Codes* folder
 
 This build does not come with Project+ assets, it only includes the Project+ source code. You will have to extract the pf folder from the Project+ download and place it in *SDCard/Project+*.
 
-Duplicate the file located at `MakeSD/SAMPLE-Config.ini` and rename the copy to `Config.ini`
+The following instructions are deprecated because MakeSD is not a directory in this repo anymore. How is this accomplished in the current build?
 
-Set SD_CARD_PATH in `MakeSD/Config.ini` to the path of the sd.raw used by your configuration of Dolphin
+~~Duplicate the file located at `MakeSD/SAMPLE-Config.ini` and rename the copy to `Config.ini`~~
 
-Set CMAKE_BUILD_DIR in `MakeSD/Config.ini` to the path that cmake builds to (default should be `.\build\Output`)
+~~Set SD_CARD_PATH in `MakeSD/Config.ini` to the path of the sd.raw used by your configuration of Dolphin~~
+
+~~Set CMAKE_BUILD_DIR in `MakeSD/Config.ini` to the path that cmake builds to (default should be `.\build\Output`)"~~
 
 Get submodule for EXI structures: `git submodule update --init --recursive`
 


### PR DESCRIPTION
Making a pr so can make an issue. Not sure how best to flag this. Unclear in docs how to deal with sd.raw. Do you have to do anything at all or just something undocumented?